### PR TITLE
Add Meta PE Core model support with runtime model selection

### DIFF
--- a/Makimus-AI.py
+++ b/Makimus-AI.py
@@ -538,9 +538,10 @@ class ImageSearchApp:
             self.root.after(0, lambda: self.update_status("Ready", "green"))
             safe_print(f"[LOAD] Success!\n")
         except Exception as e:
-            safe_print(f"[ERROR] {e}")
+            err_msg = str(e)
+            safe_print(f"[ERROR] {err_msg}")
             self.root.after(0, lambda: self.update_status("Load Failed", "red"))
-            self.root.after(0, lambda: messagebox.showerror("Error", f"Failed to load model\n{e}"))
+            self.root.after(0, lambda: messagebox.showerror("Error", f"Failed to load model\n{err_msg}"))
         self.model_loading = False
 
     def on_reload_model(self):


### PR DESCRIPTION
Introduces a MODEL_CONFIGS registry containing three vision models:
- ViT-L-14 (LAION2B) — existing default, unchanged behaviour
- PE-Core-L14-336 — Meta Perception Encoder Large (336 px, 1024-dim)
- PE-Core-G14-448 — Meta Perception Encoder Giant (448 px, 1280-dim)

Key changes:
- HybridCLIPModel now accepts a model_key and resolves name, pretrained weights, and image_size from MODEL_CONFIGS; hub models (hf-hub:timm/*) are loaded without a separate pretrained string
- ONNX dummy-input and preprocess_image_onnx use self.image_size instead of the hard-coded 224, so each model gets the correct crop size
- ONNX cache path is derived from the model key to avoid collisions
- get_cache_filename builds a model-specific .pkl name; the ViT-L-14 name is unchanged (.clip_cache_ViT-L-14_LAION2B.pkl) for compatibility
- UI gains a model-selector Combobox and a "Load Model" button; switching models clears embeddings/cache in memory (incompatible across models) and reloads the model in a background thread with VRAM cleanup

https://claude.ai/code/session_01F61k4xxCiLt7hTQ6sqqLUF